### PR TITLE
TT-213: do not show current time reports in the admin area

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    time_tracker_extension (0.3.11)
+    time_tracker_extension (0.3.13)
       pry-rails
       rails (~> 6.0)
       telegram-bot

--- a/app/controllers/time_tracker_extension/v1/admin/time_reports_controller.rb
+++ b/app/controllers/time_tracker_extension/v1/admin/time_reports_controller.rb
@@ -4,7 +4,7 @@ module TimeTrackerExtension
     before_action :authorize_action
 
     def index
-      @periods = user_time_reports.order(end_of_period: :desc).limit(10)
+      @periods = user_time_reports.where("end_of_period < ?", Date.today).order(end_of_period: :desc).limit(10)
     end
 
     def update

--- a/lib/time_tracker_extension/version.rb
+++ b/lib/time_tracker_extension/version.rb
@@ -1,3 +1,3 @@
 module TimeTrackerExtension
-  VERSION = '0.3.11'
+  VERSION = '0.3.13'
 end

--- a/spec/controllers/time_tracker_extension/v1/admin/time_reports_controller_spec.rb
+++ b/spec/controllers/time_tracker_extension/v1/admin/time_reports_controller_spec.rb
@@ -6,15 +6,16 @@ module TimeTrackerExtension
     login_admin
 
     describe "GET #index" do
-      it "should return list of time locking periods for user" do
+      it "should return list of non current time locking periods for user" do
 
         workspace = create(:workspace)
         workspace_2 = create(:workspace)
 
         user = create(:user, active_workspace: workspace, workspace_ids: [workspace.id])
-        time_report = create(:time_locking_period, user: user, workspace: workspace)
-        time_report_2 = create(:time_locking_period, workspace: workspace)
-        time_report_3 = create(:time_locking_period, user: user)
+        time_report = create(:time_locking_period, user: user, workspace: workspace, end_of_period: Date.today - 1.day)
+        time_report_2 = create(:time_locking_period, workspace: workspace, end_of_period: Date.today - 1.day)
+        time_report_3 = create(:time_locking_period, user: user, end_of_period: Date.today - 1.day)
+        time_report_4 = create(:time_locking_period, user: user, workspace: workspace, end_of_period: Date.today + 1.day)
 
         allow(controller).to receive(:current_workspace_id) { workspace.id }
         get :index, params: { user_id: user.id, format: :json }


### PR DESCRIPTION
https://trello.com/c/BSJlIFoH/213-show-only-past-time-reports-skip-current