### PR TITLE
TT-186: changed method's name 'owner_for_workspace' -> 'workspace_owner'

### DIFF
--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -32,7 +32,7 @@ class User < ApplicationRecord
     role == 'owner'
   end
 
-  def owner_for_workspace?(workspace_id)
+  def workspace_owner?(workspace_id)
     role(workspace_id) == 'owner'
   end
 end

--- a/spec/dummy/app/policies/application_policy.rb
+++ b/spec/dummy/app/policies/application_policy.rb
@@ -13,11 +13,11 @@ class ApplicationPolicy
   end
 
   def user_is_admin?
-    user? && user.try(:admin?)
+    user? && user.admin?
   end
 
   def user_is_owner?
-    user? && user.try(:owner?)
+    user? && user.owner?
   end
 
   def user_is_manager?
@@ -29,7 +29,7 @@ class ApplicationPolicy
   end
 
   def workspace_belongs_to_user?
-    user.owner_for_workspace?(record.id)
+    user.workspace_owner?(record.id)
   end
 
 end


### PR DESCRIPTION
https://trello.com/c/DBdRl6E5/186-think-about-separating-access-between-admins-users-and-owner