### PR TITLE
TT-230: moved user's logic to the form extension

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    time_tracker_extension (0.4.0)
+    time_tracker_extension (0.4.1)
       pry-rails
       rails (~> 6.0)
       telegram-bot

--- a/app/forms/time_tracker_extension/users/create_form_extension.rb
+++ b/app/forms/time_tracker_extension/users/create_form_extension.rb
@@ -1,0 +1,13 @@
+module TimeTrackerExtension
+  module Users
+    module CreateFormExtension
+
+      private
+
+      def user_attributes
+        super.merge({ telegram_token: SecureRandom.hex})
+      end
+
+    end
+  end
+end

--- a/app/models/time_tracker_extension/user_extension.rb
+++ b/app/models/time_tracker_extension/user_extension.rb
@@ -4,19 +4,11 @@ module TimeTrackerExtension
       klass.class_eval do
         has_many :time_locking_periods, class_name: '::TimeTrackerExtension::TimeLockingPeriod'
 
-        before_create :generate_telegram_token
-
         def unapproved_periods
           time_locking_periods
             .where("workspace_id = ? AND approved = false AND end_of_period < ?", active_workspace_id, Date.today)
         end
 
-        private
-
-        def generate_telegram_token
-          self.telegram_token = SecureRandom.hex
-        end
-        
       end
     end
   end

--- a/app/services/time_tracker_extension/daily_reports_sender.rb
+++ b/app/services/time_tracker_extension/daily_reports_sender.rb
@@ -17,8 +17,13 @@ module TimeTrackerExtension
           workspace_name: workspace.name,
           users_data: users_data(workspace)
         }
-        workspace.users.where("users_workspaces.role = ?", UsersWorkspace.roles["admin"]).each do |admin|
-          ::UserNotifier.new(admin, :daily_report, { report_data: report_data }).perform
+        workspace.users.where("users_workspaces.role IN (?)", roles).each do |user|
+          ::UserNotifier.new(
+            user: user,
+            notification_type: :daily_report,
+            additional_data: { report_data: report_data },
+            workspace_id: workspace.id
+          ).perform
         end
       end
 
@@ -32,6 +37,10 @@ module TimeTrackerExtension
           }
           data
         end
+      end
+
+      def roles
+        UsersWorkspace.roles.fetch_values("admin", "owner")
       end
 
     end

--- a/app/services/time_tracker_extension/time_locking_periods_checker.rb
+++ b/app/services/time_tracker_extension/time_locking_periods_checker.rb
@@ -18,7 +18,12 @@ module TimeTrackerExtension
 
       def notify_users_about_timereports(periods)
         periods.each do |period|
-          ::UserNotifier.new(period.user, :approve_period, { period: period }).perform
+          ::UserNotifier.new(
+            user: period.user,
+            notification_type: :approve_period,
+            additional_data: { period: period },
+            workspace_id: period.workspace_id
+          ).perform
         end
       end
 

--- a/app/views/time_tracker_extension/v1/users/_show.json.jbuilder
+++ b/app/views/time_tracker_extension/v1/users/_show.json.jbuilder
@@ -1,4 +1,4 @@
-json.(user, :id, :email, :name, :locale, :active_workspace_id, :telegram_token)
+json.(user, :id, :email, :name, :locale, :active_workspace_id, :telegram_token, :notification_settings)
 
 json.role user.role(@current_workspace_id)
 json.telegram_active user.telegram_id.present?
@@ -7,5 +7,3 @@ json.unapproved_periods user.unapproved_periods do |period|
   json.from period.beginning_of_period.strftime("%d/%m/%Y")
   json.to period.end_of_period.strftime("%d/%m/%Y")
 end
-
-json.notification_settings user.notification_settings.rules

--- a/lib/time_tracker_extension/version.rb
+++ b/lib/time_tracker_extension/version.rb
@@ -1,3 +1,3 @@
 module TimeTrackerExtension
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end

--- a/spec/controllers/time_tracker_extension/v1/auth_controller_spec.rb
+++ b/spec/controllers/time_tracker_extension/v1/auth_controller_spec.rb
@@ -53,14 +53,14 @@ module TimeTrackerExtension
             locale: @current_user.locale,
             active_workspace_id: @current_user.active_workspace_id,
             telegram_token: @current_user.telegram_token,
+            notification_settings: ['email_assign_user_to_project'],
             role: @current_user.role,
             telegram_active: @current_user.telegram_id.present?,
             unapproved_periods: [{
               id: period.id,
               from: period.beginning_of_period.strftime("%d/%m/%Y"),
               to: period.end_of_period.strftime("%d/%m/%Y")
-            }],
-            notification_settings: []
+            }]
           }.to_json)
         end
       end

--- a/spec/dummy/app/models/users_workspace.rb
+++ b/spec/dummy/app/models/users_workspace.rb
@@ -1,6 +1,14 @@
 class UsersWorkspace < ApplicationRecord
-  enum role: { owner: 0, admin: 1, staff: 2}
+  enum role: { staff: 0, admin: 1, owner: 2 }
+
+  before_create :set_notification_rules
 
   belongs_to :workspace
   belongs_to :user
+
+  private
+
+  def set_notification_rules
+    self.notification_rules = ['email_assign_user_to_project']
+  end
 end

--- a/spec/dummy/app/models/workspace.rb
+++ b/spec/dummy/app/models/workspace.rb
@@ -6,4 +6,9 @@ class Workspace < ApplicationRecord
   has_many :projects, dependent: :destroy
   has_many :time_records, through: :projects
 
+  validates :name, presence: true
+
+  def belongs_to_user?(user_id)
+    self.user_ids.include?(user_id)
+  end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,17 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_09_115958) do
+ActiveRecord::Schema.define(version: 2020_08_21_184606) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "notification_settings", force: :cascade do |t|
-    t.jsonb "rules", default: []
-    t.integer "user_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
 
   create_table "projects", force: :cascade do |t|
     t.string "name"
@@ -97,9 +90,10 @@ ActiveRecord::Schema.define(version: 2020_08_09_115958) do
   create_table "users_workspaces", force: :cascade do |t|
     t.bigint "workspace_id", null: false
     t.bigint "user_id", null: false
-    t.integer "role"
-    t.index ["user_id", "workspace_id"], name: "index_users_workspaces_on_user_id_and_workspace_id"
-    t.index ["workspace_id", "user_id"], name: "index_users_workspaces_on_workspace_id_and_user_id"
+    t.integer "role", default: 0
+    t.jsonb "notification_rules", default: []
+    t.index ["user_id", "workspace_id"], name: "index_users_workspaces_on_user_id_and_workspace_id", unique: true
+    t.index ["workspace_id", "user_id"], name: "index_users_workspaces_on_workspace_id_and_user_id", unique: true
   end
 
   create_table "workspaces", force: :cascade do |t|

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -2,10 +2,12 @@ FactoryBot.define do
 
   factory :user do
 
-    after(:create) do |object|
-      object.active_workspace.users << object
-      if object.notification_settings.nil?
-        object.create_notification_settings
+    before(:create) do |object|
+      if object.active_workspace_id.nil?
+        workspace = create(:workspace)
+        object.active_workspace = workspace
+      else
+        object.workspaces << object.active_workspace
       end
     end
 
@@ -13,6 +15,7 @@ FactoryBot.define do
     email    { Faker::Internet.unique.email }
     password { "password" }
     association :active_workspace, factory: :workspace
+    telegram_token { SecureRandom.hex }
 
     trait :owner do
       after(:create) do |object|

--- a/spec/forms/users/create_form_extension_spec.rb
+++ b/spec/forms/users/create_form_extension_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+class DummyUsersCreateForm
+  prepend TimeTrackerExtension::Users::CreateFormExtension
+
+  def persist!
+    user_attributes
+  end
+
+  def user_attributes
+    { id: 1 }
+  end
+
+end
+
+module TimeTrackerExtension
+  module Users
+    RSpec.describe CreateFormExtension do
+      describe "user_attributes" do
+        it "should add telegram token to the original user's attributes" do
+          allow(SecureRandom).to receive(:hex) { '1111' }
+          expect(DummyUsersCreateForm.new.persist!).to eq({
+            id: 1,
+            telegram_token: '1111'
+          })
+        end
+      end
+    end
+  end
+end

--- a/spec/models/time_tracker_extension/time_locking_period_spec.rb
+++ b/spec/models/time_tracker_extension/time_locking_period_spec.rb
@@ -11,7 +11,7 @@ module TimeTrackerExtension
         let!(:today) { Date.today }
         let!(:workspace) { create(:workspace) }
         let!(:project) { create(:project, workspace: workspace) }
-        let!(:user) { create(:user, active_workspace_id: workspace.id, workspace_ids: [workspace.id]) }
+        let!(:user) { create(:user, active_workspace_id: workspace.id) }
 
         let!(:time_locking_period) do
           create(:time_locking_period,
@@ -62,7 +62,7 @@ module TimeTrackerExtension
     describe "#unblock!" do
       let!(:today) { Date.today }
       let!(:workspace) { create(:workspace) }
-      let!(:user) { create(:user, active_workspace_id: workspace.id, workspace_ids: [workspace.id]) }
+      let!(:user) { create(:user, active_workspace_id: workspace.id) }
 
       let!(:current_time_locking_period) do
         create(:time_locking_period,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,14 +18,4 @@ RSpec.describe Workspace, type: :model do
     end
   end
 
-  describe "generate_telegram_token" do
-    it "should add Telegram token to new user before creating" do
-      user = build(:user, active_workspace: create(:workspace))
-      expect(user.telegram_token).to be_nil
-      allow(SecureRandom).to receive(:hex) { 'token' }
-      user.save
-      expect(User.last.telegram_token).to eq('token')
-    end
-  end
-
 end

--- a/spec/services/time_tracker_extension/daily_reports_sender_spec.rb
+++ b/spec/services/time_tracker_extension/daily_reports_sender_spec.rb
@@ -37,7 +37,12 @@ module TimeTrackerExtension
 
       workspace.users << [staff]
       allow(workspace).to receive_message_chain(:users, :where) { [admin] }
-      expect(::UserNotifier).to receive(:new).with(admin, :daily_report, { report_data: report_data }) { double(perform: true) }
+      expect(::UserNotifier).to receive(:new).with({
+        user: admin,
+        notification_type: :daily_report,
+        additional_data: { report_data: report_data },
+        workspace_id: workspace.id
+      }) { double(perform: true) }
       TimeTrackerExtension::DailyReportsSender.execute
       travel_back
     end

--- a/spec/services/time_tracker_extension/time_locking_periods_checker_spec.rb
+++ b/spec/services/time_tracker_extension/time_locking_periods_checker_spec.rb
@@ -19,16 +19,23 @@ module TimeTrackerExtension
 
     describe ".execute" do
       it "should build notifier" do
-        expect(::UserNotifier).to receive(:new)
-          .with(user, :approve_period, { period: period }) { double(perform: true)}
-
+        expect(::UserNotifier).to receive(:new).with({
+          user: user,
+          notification_type: :approve_period,
+          additional_data: { period: period },
+          workspace_id: period.workspace_id
+        }) { double(perform: true)}
         launch_service
       end
 
       it "should launch notifier" do
         notifier = double
-        allow(::UserNotifier).to receive(:new)
-          .with(user, :approve_period, { period: period }) { notifier }
+        allow(::UserNotifier).to receive(:new).with({
+          user: user,
+          notification_type: :approve_period,
+          additional_data: { period: period },
+          workspace_id: period.workspace_id
+        }) { notifier }
         expect(notifier).to receive(:perform)
         launch_service
       end


### PR DESCRIPTION
https://trello.com/c/GQQgRGUY/230-managing-notifications-should-be-in-scope-of-workspace

Also used scoped notification rules for sending messages to users
