### PR TITLE
Updated telegram-bot gem's version to 0.15.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    telegram-bot (0.15.1)
+    telegram-bot (0.15.2)
       actionpack (>= 4.0, < 6.2)
       activesupport (>= 4.0, < 6.2)
       httpclient (~> 2.7)


### PR DESCRIPTION
# 0.15.2

- Ruby 3.0 support. Drop support for Ruby < 2.4.
